### PR TITLE
Migrator postfixes directories with /**

### DIFF
--- a/packages/code-captains-migrator/src/cmds/__tests__/migrate.test.ts
+++ b/packages/code-captains-migrator/src/cmds/__tests__/migrate.test.ts
@@ -90,6 +90,32 @@ const migrateEntryTestCases: { line: string; maximizeDepth: boolean; policy: Dir
             codeCaptains: ["@upshift"],
         },
     },
+    {
+        // NOTE(thomas): This test depends on directories in our repo and the test CWD
+        line: "packages @upshift",
+        maximizeDepth: true,
+        policy: {
+            sourceFilePath: "code-captains.yml",
+            fileFilter: {
+                includePatterns: ["packages/**"],
+                excludePatterns: [],
+            },
+            codeCaptains: ["@upshift"],
+        },
+    },
+    {
+        // NOTE(thomas): This test depends on directories in our repo and the test CWD
+        line: "packages/code-captains-migrator/src @migrator",
+        maximizeDepth: true,
+        policy: {
+            sourceFilePath: "packages/code-captains-migrator/code-captains.yml",
+            fileFilter: {
+                includePatterns: ["src/**"],
+                excludePatterns: [],
+            },
+            codeCaptains: ["@migrator"],
+        },
+    },
 ];
 
 test.for(migrateEntryTestCases)("migrateEntry %#", async (testCase) => {

--- a/packages/code-captains-migrator/src/cmds/migrate.ts
+++ b/packages/code-captains-migrator/src/cmds/migrate.ts
@@ -1,5 +1,5 @@
 import { once } from "events";
-import { createReadStream } from "fs";
+import { createReadStream, existsSync, statSync } from "fs";
 import { createInterface } from "readline/promises";
 
 import { DirectoryPolicy, writeRepoPolicy } from "@upshift-dev/code-captains-core";
@@ -42,10 +42,19 @@ export const migrateEntry = (line: string, maximizeDepth: boolean = false): Dire
         pathIndex += 1;
     }
 
+    let pattern = pathElements.slice(pathIndex).join("/");
+    if (!path.endsWith("*")) {
+        // If the path doesn't end with *, we stat the FS entry to see if it is a dir or a file
+        // If it's a dir, we append /** to the end
+        if (existsSync(path) && statSync(path).isDirectory()) {
+            pattern += "/**";
+        }
+    }
+
     return {
         sourceFilePath: `${sourceFilePathPrefix}code-captains.yml`,
         fileFilter: {
-            includePatterns: [pathElements.slice(pathIndex).join("/")],
+            includePatterns: [pattern],
             excludePatterns: [],
         },
         codeCaptains: actualCaptains,


### PR DESCRIPTION
If a user is migrating a CODEOWNERS entry that points to a directory, we will do our best to postfix the entry with `/**`.